### PR TITLE
Fix deprecated Poetry --no-dev flag in nixpacks.toml

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -4,7 +4,7 @@ nixPkgs = ["nodejs", "python312", "poetry"]
 [phases.install]
 cmds = [
   "cd frontend && npm install",
-  "cd backend && poetry install --no-dev"
+  "cd backend && poetry install --only=main"
 ]
 
 [phases.build]


### PR DESCRIPTION
- Update 'poetry install --no-dev' to 'poetry install --only=main'
- Resolves deployment failure due to deprecated Poetry command
- Ensures compatibility with current Poetry versions